### PR TITLE
Include WASI artifacts as part of the release workflow

### DIFF
--- a/.github/actions/package_wasi/action.yml
+++ b/.github/actions/package_wasi/action.yml
@@ -6,6 +6,10 @@ inputs:
   wasisdk_version:
     required: true
     description: "WASI SDK version"
+  include_build_artifacts:
+    required: false
+    default: false
+    description: "Include build artifacts (such as `.a` files)"
 runs:
   using: "composite"
   steps:
@@ -77,4 +81,4 @@ runs:
           ${{ env.HOST_PYTHON_DIR }}/Modules/expat/libexpat.a
           ${{ env.HOST_PYTHON_DIR }}/Programs/python.o
         if-no-files-found: error
-      if: "false"
+      if: inputs.include_build_artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
         id: package
         with:
           wasisdk_version: "${{ inputs.wasisdk_version }}"
+          include_build_artifacts: true
       - name: Upload artifact
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
The files are not included in the release artifacts in case there are storage quota concerns. The files themselves are useful for building extension modules to be statically linked with the CPython WASI build.